### PR TITLE
Feature/recaptcha enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ oh_media_antispam:
 
 Under `captcha` you can specify `type` as "hcaptcha" or "recaptcha" (default).
 
-_**Note:** `sitekey` and `secretkey` are omitted in the default config because the bundle
+<!-- TODO -->
+_**Note:** `sitekey` and `projectId` are omitted in the default config because the bundle
 will provide test keys._
 
 Override on the live site with `config/packages/prod/oh_media_antispam.yaml`:
@@ -56,7 +57,7 @@ oh_media_antispam:
     captcha:
         type: 'recaptcha' # or 'hcaptcha'
         sitekey: 'my_publishable_key'
-        secretkey: 'my_secret_key'
+        projectId: 'my_secret_key'
 ```
 
 You will want to ignore this prod file in your repository.

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -3,7 +3,7 @@ services:
         tags: ["form.type"]
 
     OHMedia\AntispamBundle\Validator\CaptchaValidator:
-        arguments: ["@request_stack", "%oh_media_antispam.captcha.secretkey%", "%oh_media_antispam.captcha.type%"]
+        arguments: ["@kernel", "@request_stack", "%oh_media_antispam.captcha.projectId%", "%oh_media_antispam.captcha.sitekey%", "%oh_media_antispam.captcha.type%"]
         tags: ["validator.constraint_validator"]
 
     OHMedia\AntispamBundle\Form\Extension\FormTypeHoneypotExtension:

--- a/src/OHMediaAntispamBundle.php
+++ b/src/OHMediaAntispamBundle.php
@@ -26,7 +26,7 @@ class OHMediaAntispamBundle extends AbstractBundle
                             ->end()
                         ->end()
                         ->scalarNode('sitekey')->end()
-                        ->scalarNode('secretkey')->end()
+                        ->scalarNode('projectId')->end()
                         ->scalarNode('theme')
                             ->defaultValue('light')
                             ->validate()
@@ -50,17 +50,17 @@ class OHMediaAntispamBundle extends AbstractBundle
     public function loadExtension(
         array $config,
         ContainerConfigurator $containerConfigurator,
-        ContainerBuilder $containerBuilder
+        ContainerBuilder $containerBuilder,
     ): void {
         $containerConfigurator->import('../config/services.yaml');
 
-        if (empty($config['captcha']['sitekey']) || empty($config['captcha']['secretkey'])) {
+        if (empty($config['captcha']['sitekey']) || empty($config['captcha']['projectId'])) {
             if (self::CAPTCHA_TYPE_HCAPTCHA === $config['captcha']['type']) {
                 $config['captcha']['sitekey'] = '10000000-ffff-ffff-ffff-000000000001';
-                $config['captcha']['secretkey'] = '0x0000000000000000000000000000000000000000';
+                $config['captcha']['projectId'] = '0x0000000000000000000000000000000000000000';
             } elseif (self::CAPTCHA_TYPE_RECAPTCHA === $config['captcha']['type']) {
                 $config['captcha']['sitekey'] = '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI';
-                $config['captcha']['secretkey'] = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe';
+                $config['captcha']['projectId'] = '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe';
             }
         }
 

--- a/src/Validator/CaptchaValidator.php
+++ b/src/Validator/CaptchaValidator.php
@@ -2,8 +2,13 @@
 
 namespace OHMedia\AntispamBundle\Validator;
 
+use Google\Cloud\RecaptchaEnterprise\V1\Assessment;
+use Google\Cloud\RecaptchaEnterprise\V1\Client\RecaptchaEnterpriseServiceClient;
+use Google\Cloud\RecaptchaEnterprise\V1\CreateAssessmentRequest;
+use Google\Cloud\RecaptchaEnterprise\V1\Event;
 use OHMedia\AntispamBundle\OHMediaAntispamBundle;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -12,14 +17,14 @@ class CaptchaValidator extends ConstraintValidator
     private $url;
 
     public function __construct(
+        private KernelInterface $kernel,
         private RequestStack $requestStack,
-        private string $secretkey,
-        private string $type
+        private string $projectId,
+        private string $sitekey,
+        private string $type,
     ) {
         if (OHMediaAntispamBundle::CAPTCHA_TYPE_HCAPTCHA === $type) {
             $this->url = 'https://hcaptcha.com/siteverify';
-        } elseif (OHMediaAntispamBundle::CAPTCHA_TYPE_RECAPTCHA === $type) {
-            $this->url = 'https://www.google.com/recaptcha/api/siteverify';
         }
     }
 
@@ -34,11 +39,64 @@ class CaptchaValidator extends ConstraintValidator
         $mainRequest = $this->requestStack->getMainRequest();
         $remoteip = $mainRequest->getClientIp();
 
+        if (OHMediaAntispamBundle::CAPTCHA_TYPE_HCAPTCHA === $this->type) {
+            $this->hcaptcha($value, $constraint, $remoteip);
+        } elseif (OHMediaAntispamBundle::CAPTCHA_TYPE_RECAPTCHA === $this->type) {
+            $this->recaptcha($value, $constraint, $remoteip);
+        }
+    }
+
+    private function recaptcha(string $value, Constraint $constraint, string $remoteip): void
+    {
+        try {
+            $credsPath = $this->kernel->getProjectDir().'/credentials.json';
+
+            if (!file_exists($credsPath)) {
+                throw new \Exception('Missing recaptcha credentials.json');
+            }
+
+            $client = new RecaptchaEnterpriseServiceClient([
+                'credentials' => $credsPath,
+            ]);
+
+            $projectName = $client->projectName($this->projectId);
+
+            $assessment = new Assessment([
+                'event' => new Event([
+                    'token' => $value,
+                    'site_key' => $this->sitekey,
+                    'user_ip_address' => $remoteip,
+                    // TODO - Should review args this takes
+                    // 'user_agent' => $userAgent,
+                ]),
+            ]);
+
+            $request = (new CreateAssessmentRequest())
+                ->setParent($projectName)
+                ->setAssessment($assessment);
+
+            $response = $client->createAssessment($request);
+
+            // TODO - potential to enable this through config with value per client.
+            // $score = $response->getRiskAnalysis()->getScore() ?? 0.0;
+        } catch (\Exception $e) {
+            $this->context->addViolation($constraint->message);
+        }
+    }
+
+    /**
+     * Validate hcaptcha.
+     *
+     * @throws \JsonException
+     */
+    // TODO - For simplicity I wonder if we just stick with recaptcha?
+    private function hcaptcha(string $value, Constraint $constraint, string $remoteip): void
+    {
         $opts = ['http' => [
             'method' => 'POST',
             'header' => 'Content-type: application/x-www-form-urlencoded',
             'content' => http_build_query([
-                'secret' => $this->secretkey,
+                'secret' => $this->projectId,
                 'response' => $value,
                 'remoteip' => $remoteip,
             ]),

--- a/templates/captcha_script.html.twig
+++ b/templates/captcha_script.html.twig
@@ -12,15 +12,15 @@
         if (OHMEDIA_ANTISPAM_CAPTCHA_LOADED) {
           clearInterval(interval);
 
-          const widgetId = grecaptcha.render(container, parameters);
+          const widgetId = grecaptcha.enterprise.render(container, parameters);
 
           resolve({
             reset() {
-              return grecaptcha.reset(widgetId);
+              return grecaptcha.enterprise.reset(widgetId);
             },
 
             getResponse() {
-              return grecaptcha.getResponse(widgetId);
+              return grecaptcha.enterprise.getResponse(widgetId);
             },
           });
         }
@@ -96,5 +96,5 @@
 {% if is_type_hcaptcha %}
   <script src="https://js.hcaptcha.com/1/api.js?onload=OHMEDIA_ANTISPAM_CAPTCHA_CALLBACK&render=explicit&recaptchacompat=on" async defer></script>
 {% elseif is_type_recaptcha %}
-  <script src="https://www.google.com/recaptcha/api.js?onload=OHMEDIA_ANTISPAM_CAPTCHA_CALLBACK&render=explicit" async defer></script>
+  <script src="https://www.google.com/recaptcha/enterprise.js?onload=OHMEDIA_ANTISPAM_CAPTCHA_CALLBACK&render=explicit" async defer></script>
 {% endif %}


### PR DESCRIPTION
## Info
Google recaptcha keys are now all under Google cloud projects within the enterprise API. When you go into the key integration section within the cloud console they now have the `secret key` marked as `legacy secret key` which indicated to me that the old implementation could get deprecated at some point in the years to come. I think at a minimum we should update our v6 codebase to the latest implementation.

## Testing
I created a test key and viewer under the test project. You'll need to get the credentials.json file from me and place it in the project root for this to funciton

## Future thoughts 

Probably more for a BE meeting but also to record my thoughts as a reminder.

• I wonder if we should stick to recaptcha over hcaptcha for simplicity. The project limit appears to be 1000 from what I could tell and this should simplify billing once we have a project per client.

• I think we could revisit rejections based on score. This could be a config option that is defaulted to off and only turned on conservatively for specific clients with their consent and understanding on the implications.

• Have not tried this yet, but this could be a good v6 security feature that we can point out and have clients actually understand
https://docs.cloud.google.com/recaptcha/docs/check-passwords

• Noticed they also have a 2-factor feature in preview. Something we can maybe look at in the future as something to upsell. Less of a priority to me though
https://docs.cloud.google.com/recaptcha/docs/integrate-account-verification

## Ref

https://docs.cloud.google.com/recaptcha/docs/migrate-recaptcha